### PR TITLE
Add Unicode Histogram functionality

### DIFF
--- a/src/precis.jl
+++ b/src/precis.jl
@@ -42,7 +42,7 @@ function unicode_histogram(data, nbins = 12)
   # result in indices 0:8 which breaks things
   scaled = f.weights .* (length(BARS) / maximum(f.weights) - eps())
   indices = floor.(Int, scaled) .+ 1
-  return join((bars[i] for i in indices))
+  return join((BARS[i] for i in indices))
 end
 
 

--- a/src/precis.jl
+++ b/src/precis.jl
@@ -1,3 +1,5 @@
+using StatsBase
+
 function precis(df::DataFrame; digits=3, depth=Inf, alpha=0.11)
   m = zeros(length(names(df)), 5)
   for (indx, col) in enumerate(names(df))
@@ -29,6 +31,20 @@ end
 function precis(m::SampleModel)
   precis(read_samples(m; output_format=:dataframe))
 end
+
+
+const BARS = collect("▁▂▃▄▅▆▇█")
+
+function unicode_histogram(data, nbins = 12)
+  f = fit(Histogram, data, nbins = nbins)  # nbins: more like a guideline than a rule, really
+  # scale weights between 1 and 8 (length(BARS)) to fit the indices in BARS
+  # eps is needed so indices are in the interval [0, 8) instead of [0, 8] which could
+  # result in indices 0:8 which breaks things
+  scaled = f.weights .* (length(BARS) / maximum(f.weights) - eps())
+  indices = floor.(Int, scaled) .+ 1
+  return join((bars[i] for i in indices))
+end
+
 
 export
   precis


### PR DESCRIPTION
Example usage:
```
d = CSV.read(datadir("exp_raw/Howell_1.csv"), copycols = true)
for col in eachcol(d)
    println(unicode_histogram(col))
end
```
gives
```
▁▁▁▂▂▂▂▂▂██▆▁
▁▃▄▄▃▂▃▆██▅▃▁
█▆▆▆▆▃▃▁▁
█▁▁▁▁▁▁▁▁▁█
```

I'm not sure how to incorporate this with `precis` since it would probably turn the array type in to a `Union`. Unicode and font coverage is also necessary but that seems to be pretty good in the Julia community (heavy Unicode symbol usage, strings are UTF-8...).