### PR TITLE
Use rand(...) instead of rand(..., 1)[1]

### DIFF
--- a/research/pb_ribbon_test.jl
+++ b/research/pb_ribbon_test.jl
@@ -56,7 +56,7 @@ function plotbounds_ribbons(
       for j in 1:nrow(dfs)
         p_sim[i, j] = 
           ybar .+ rand(Normal(dfs[j, linkvars[1]] + ystd/xstd * dfs[j, 
-            linkvars[2]] * (x[i] - xbar), ystd*dfs[j, linkvars[3]]), 1)[1]
+            linkvars[2]] * (x[i] - xbar), ystd*dfs[j, linkvars[3]]))
       end
     end
 

--- a/research/ribbon_test.jl
+++ b/research/ribbon_test.jl
@@ -6,8 +6,8 @@ ProjDir = @__DIR__
 
 n = 100
 df = DataFrame(:M => rand(Normal(), n));
-df[!, :NC] = [rand(Normal(df[i, :M]), 1)[1] for i in 1:n];
-df[!, :K] = [rand(Normal(df[i, :NC] - df[i, :M]), 1)[1] for i in 1:n];
+df[!, :NC] = [rand(Normal(df[i, :M])) for i in 1:n];
+df[!, :K] = [rand(Normal(df[i, :NC] - df[i, :M])) for i in 1:n];
 scale!(df, [:K, :M, :NC])
 
 include("$(ProjDir)/m5.7_A.jl") 

--- a/src/plotbounds.jl
+++ b/src/plotbounds.jl
@@ -90,7 +90,7 @@ function plotbounds(
     for i in 1:length(x)
       for j in 1:nrow(dfs)
         predictions[i, j] = 
-          ybar .+ rand(Normal(dfs[j, linkvars[1]] + ystd/xstd * dfs[j, linkvars[2]] * (x[i] - xbar), ystd*dfs[j, linkvars[3]]), 1)[1] 
+          ybar .+ rand(Normal(dfs[j, linkvars[1]] + ystd/xstd * dfs[j, linkvars[2]] * (x[i] - xbar), ystd*dfs[j, linkvars[3]]))
       end
     end
     pred_hpd = [hpdi(predictions[i, :], alpha=alpha) for i in 1:length(x)]

--- a/src/require/hmc.jl
+++ b/src/require/hmc.jl
@@ -57,7 +57,7 @@ function HMC(model, grad, epsilon, L, current_q)
   # Return either position at the end or initial position
   local accept = 0
   local new_q
-  if rand(Uniform(0, 1), 1)[1] < exp(dH)
+  if rand(Uniform(0, 1)) < exp(dH)
     new_q = q # Accept
     accept = 1
   else

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -23,7 +23,7 @@ function simulate(df, coefs, var_seq)
   for j in 1:size(df, 1)
     for i in 1:length(var_seq)
       d = Normal(df[j, coefs[1]] + df[j, coefs[2]] * var_seq[i], df[j, coefs[3]])
-      m_sim[j, i] = rand(d, 1)[1]
+      m_sim[j, i] = rand(d)
     end
   end
   m_sim
@@ -57,7 +57,7 @@ function simulate(df, coefs, var_seq, coefs_ext)
     for i in 1:length(var_seq)
       d = Normal(df[j, coefs[1]] + df[j, coefs[2]] * var_seq[i] +
         df[j, coefs_ext[1]] * m_sim[j, i], df[j, coefs_ext[2]])
-      d_sim[j, i] = rand(d, 1)[1]
+      d_sim[j, i] = rand(d)
     end
   end
   (m_sim, d_sim)


### PR DESCRIPTION
Hi! I noticed that some nested loops calculate `rand(d, 1)[1]` a lot. This can be sped up by using `rand()`.

```
julia> using Random

julia> Random.seed!(1234); rand(1)[1]
0.5908446386657102

julia> Random.seed!(1234); rand()
0.5908446386657102
```