### PR TITLE
Coeftab_plot improvements

### DIFF
--- a/src/coeftab_plot.jl
+++ b/src/coeftab_plot.jl
@@ -9,6 +9,7 @@ $(SIGNATURES)
 # Arguments
 - `dfs::DataFrame`: list of dataframes with sampled model parameters
 - `pars`: list of column names (as symbols) to analyze. If not given, take all columns
+- `pars_names`: list of strings to be used instead of column names
 - `names`: list of dataframe names to be used in plot. If not given, "1", "2", "3"... will be used
 - `perc_prob`: probability for confidence interval calculation
 
@@ -17,7 +18,7 @@ $(SIGNATURES)
 coeftab_plots(m5_1_df, m5_2_df, m5_3_df; pars=(:bA, :bM), names=["m5.1", "m5.2", "m5.3"])
 ```
 """
-function coeftab_plot(dfs::DataFrame...; pars=missing, names=missing, perc_prob=0.89)::Plots.Plot
+function coeftab_plot(dfs::DataFrame...; pars=missing, pars_names=missing, names=missing, perc_prob=0.89)::Plots.Plot
     if ismissing(pars)
         pars = unique(Iterators.flatten(propertynames.(dfs)))
         sort!(pars)
@@ -25,17 +26,21 @@ function coeftab_plot(dfs::DataFrame...; pars=missing, names=missing, perc_prob=
     if ismissing(names)
         names = string.(Base.OneTo(length(dfs)))
     end
+    if ismissing(pars_names)
+        pars_names = string.(pars)
+    end
 
     x = Vector{Float64}()
     xerr = Vector{Tuple{Float64,Float64}}()
     y = Vector{String}()
-    for p ∈ pars
+    for (p_name, p) ∈ zip(pars_names, pars)
         for (name, df) ∈ zip(names, dfs)
             p ∈ propertynames(df) || continue
             μ = mean(df[!,p])
             err = abs.(PI(df[!,p], prob=perc_prob) .- μ)
             pushfirst!(x, μ)
-            pushfirst!(y, "$p: $name")
+            label = length(dfs) == 1 ? "$p_name" : "$p_name: $name"
+            pushfirst!(y, label)
             pushfirst!(xerr, Tuple(err))
         end
     end

--- a/src/coeftab_plot.jl
+++ b/src/coeftab_plot.jl
@@ -12,13 +12,14 @@ $(SIGNATURES)
 - `pars_names`: list of strings to be used instead of column names
 - `names`: list of dataframe names to be used in plot. If not given, "1", "2", "3"... will be used
 - `perc_prob`: probability for confidence interval calculation
+- `kwargs`: rest of arguments will be passed to the scatter function
 
 # Examples
 ```julia
 coeftab_plots(m5_1_df, m5_2_df, m5_3_df; pars=(:bA, :bM), names=["m5.1", "m5.2", "m5.3"])
 ```
 """
-function coeftab_plot(dfs::DataFrame...; pars=missing, pars_names=missing, names=missing, perc_prob=0.89)::Plots.Plot
+function coeftab_plot(dfs::DataFrame...; pars=missing, pars_names=missing, names=missing, perc_prob=0.89, kwargs...)::Plots.Plot
     if ismissing(pars)
         pars = unique(Iterators.flatten(propertynames.(dfs)))
         sort!(pars)
@@ -44,7 +45,7 @@ function coeftab_plot(dfs::DataFrame...; pars=missing, pars_names=missing, names
             pushfirst!(xerr, Tuple(err))
         end
     end
-    scatter(x, y; xerr=xerr)
+    scatter(x, y; xerr=xerr, kwargs...)
 end
 
 export


### PR DESCRIPTION
Several improvements in the `coeftab_plot` function:
* do not show dataframe name if there is only one dataframe passed
* allow to pass parameter names to be displayed instead of column names
* allow to pass extra arguments to the underlying `scatter` call

Example could be checked here (code 5.52): https://shmuma.github.io/rethinking-2ed-julia/07-Chapter%205.%20The%20Many%20Variables%20and%20The%20Spirious%20Waffles.html