### PR TITLE
Fix PI signature

### DIFF
--- a/src/srtools.jl
+++ b/src/srtools.jl
@@ -87,8 +87,29 @@ Compute percentile central interval of data. Returns vector of bounds.
 
 $(SIGNATURES)
 
+## Required arguments
+* `data`: iterable over data values
+
+## Optional arguments
+* `prob::Float64=0.89`: percentile interval to calculate
+
+## Examples
+```jldoctest
+julia> using StatisticalRethinking
+
+julia> PI(1:10)
+2-element Vector{Float64}:
+ 1.495
+ 9.505
+
+julia> PI(1:10, prob=0.1)
+2-element Vector{Float64}:
+ 5.05
+ 5.95
+
+```
 """
-function PI(data, prob=0.89)
+function PI(data; prob::Float64=0.89)
     d = (1-prob)/2
     quantile(data, [d, 1-d])
 end

--- a/test/test_srtools.jl
+++ b/test/test_srtools.jl
@@ -1,7 +1,7 @@
 @testset "PI" begin
     r = PI(1:100)
     @test r ≈ [6.445, 94.555]
-    
-    r = PI(1:100, 0.1)
+
+    r = PI(1:100, prob=0.1)
     @test r ≈ [45.55, 55.45]
 end


### PR DESCRIPTION
By changing semicolon with comma, two PI methods are being generated, which is not very good practice.