### PR TITLE
Implement sample from ModeResult

### DIFF
--- a/src/StatisticalRethinking.jl
+++ b/src/StatisticalRethinking.jl
@@ -25,6 +25,7 @@ using DocStringExtensions: SIGNATURES, FIELDS, TYPEDEF
 
 function __init__()
   @require Turing="fce5fe82-541a-59a6-adf8-730c64b5f9a0" include("require/turing/turing.jl")
+  @require Optim="429524aa-4258-5aef-a3af-852621145aeb" include("require/turing/turing_optim_sample.jl")
   @require StanSample="c1514b29-d3a0-5178-b312-660c88baa699" include("require/stan/stan.jl")
   @require LogDensityProblems="6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c" include("require/dhmc/dhmc.jl")
   @require MCMCChains="c7f686f2-ff18-58e9-bc7b-31028e88f75d" include("require/mcmcchains/mcmcchains.jl")

--- a/src/require/turing/turing_optim_sample.jl
+++ b/src/require/turing/turing_optim_sample.jl
@@ -1,0 +1,67 @@
+using Optim
+using Dates
+import StatsBase: sample
+import Turing: ModeResult
+import LinearAlgebra: Symmetric
+
+"""
+# sample
+
+Sample from ModeResult - optimisation result produced by Turing mode estimation.
+
+$(SIGNATURES)
+
+## Required arguments
+* `m::ModeResult`: mode estimation result
+* `n::Integer`: amount of samples to be drawn
+
+## Return values
+`Chains` object with drawn samples
+
+## Examples
+```jldoctest
+julia> using Optim, Turing, StatisticalRethinking
+
+julia> @model function f(x)
+           a ~ Normal()
+           x ~ Normal(a)
+       end
+f (generic function with 2 methods)
+
+julia> m = optimize(f([1,1.1]), MLE())
+ModeResult with maximized lp of -1.84
+1-element Named Vector{Float64}
+A  │
+───┼─────
+:a │ 1.05
+
+julia> sample(m, 10)
+Chains MCMC chain (10×1×1 reshape(adjoint(::Matrix{Float64}), 10, 1, 1) with eltype Float64):
+
+Iterations        = 1:1:10
+Number of chains  = 1
+Samples per chain = 10
+Wall duration     = 0.0 seconds
+Compute duration  = 0.0 seconds
+parameters        = a
+
+Summary Statistics
+  parameters      mean       std   naive_se      mcse       ess      rhat   ess_per_sec
+      Symbol   Float64   Float64    Float64   Float64   Float64   Float64       Float64
+
+           a    0.7186    0.5911     0.1869    0.1717    9.4699    0.9243     9469.8745
+
+Quantiles
+  parameters      2.5%     25.0%     50.0%     75.0%     97.5%
+      Symbol   Float64   Float64   Float64   Float64   Float64
+
+           a    0.0142    0.3041    0.6623    0.9987    1.7123
+```
+"""
+function sample(m::ModeResult, n::Int)::Chains
+    st = now()
+    μ = coef(m)
+    Σ = Symmetric(vcov(m))
+    dist = MvNormal(μ, Σ)
+    Chains(rand(dist, n)', coefnames(m), info=(start_time=st, stop_time=now()))
+end


### PR DESCRIPTION
Finally found the source of lppd mismatch with the book - during sampling I did independent sampling, but need to use full covariance matrix. It lead to different samples and, as a result, discrepancy in LPPD values computed in chapter 7.

This code implements sampling from ModeResult and produce Chains object.