### PR TITLE
fix bad PI() docstring

### DIFF
--- a/src/srtools.jl
+++ b/src/srtools.jl
@@ -91,7 +91,7 @@ $(SIGNATURES)
 * `data`: iterable over data values
 
 ## Optional arguments
-* `prob::Float64=0.89`: percentile interval to calculate
+* `perc_prob::Float64=0.89`: percentile interval to calculate
 
 ## Examples
 ```jldoctest
@@ -102,7 +102,7 @@ julia> PI(1:10)
  1.495
  9.505
 
-julia> PI(1:10; prob=0.1)
+julia> PI(1:10; perc_prob=0.1)
 2-element Vector{Float64}:
  5.05
  5.95


### PR DESCRIPTION
Hi Rob,
Hope this works.

test
----

julia test/runtests.jl
┌ Warning: Environment variable CMDSTAN_HOME not set. Use set_cmdstan_home!.
└ @ StanBase ~/.julia/packages/StanBase/EKgLz/src/StanBase.jl:52
Test Summary: | Pass  Total  Time
srtools       |    2      2  2.7s
Test Summary: | Pass  Total  Time
link          |    2      2  0.5s
Test Summary: | Pass  Total  Time
simulate      |    2      2  1.1s
Test Summary: | Pass  Total  Time
lppd          |    1      1  0.3s